### PR TITLE
Fix: linux.lua:112: attempt to call global '_l' (a nil value)

### DIFF
--- a/lua/oil-image-preview/linux.lua
+++ b/lua/oil-image-preview/linux.lua
@@ -109,8 +109,7 @@ local function listWeztermPanes()
         ("--format=%s"):format("json"),
     }, { text = true }):wait()
     local json = vim.json.decode(cli_result.stdout)
-    local panes = vim.iter(json):map(_l("obj: { pane_id = obj.pane_id, tab_id = obj.tab_id }"))
-
+    local panes = vim.iter(json):map(function(obj) return { pane_id = obj.pane_id, tab_id = obj.tab_id } end)
     return panes
 end
 


### PR DESCRIPTION
The preview gives me an error which is solved with an anonymous function.
![before](https://github.com/user-attachments/assets/a59019c6-1fcb-4c7b-af91-54f234d2786e)
After the change it works perfect.
![after](https://github.com/user-attachments/assets/087bde96-9efd-429c-b04e-11e998f7c9e7)

